### PR TITLE
Fix edit clear tag

### DIFF
--- a/src/main/java/org/teamstbf/yats/logic/parser/CliSyntax.java
+++ b/src/main/java/org/teamstbf/yats/logic/parser/CliSyntax.java
@@ -11,16 +11,16 @@ import org.teamstbf.yats.logic.parser.ArgumentTokenizer.Prefix;
 public class CliSyntax {
 
 	/* Prefix definitions */
-	public static final Prefix PREFIX_LOCATION = new Prefix("-l ");
-	public static final Prefix PREFIX_START_TIME = new Prefix("-s ");
-	public static final Prefix PREFIX_END_TIME = new Prefix("-e ");
-	public static final Prefix PREFIX_TAG = new Prefix("-t ");
-	public static final Prefix PREFIX_DESCRIPTION = new Prefix("-d ");
-	public static final Prefix PREFIX_DEADLINE = new Prefix("-by ");
-	public static final Prefix PREFIX_RECURRENCE = new Prefix("-r ");
-	public static final Prefix PREFIX_HOURS = new Prefix("-h ");
-	public static final Prefix PREFIX_MINUTES = new Prefix("-m ");
-	public static final Prefix PREFIX_TIME_MULTIPLE = new Prefix("-time ");
+	public static final Prefix PREFIX_LOCATION = new Prefix("-l");
+	public static final Prefix PREFIX_START_TIME = new Prefix("-s");
+	public static final Prefix PREFIX_END_TIME = new Prefix("-e");
+	public static final Prefix PREFIX_TAG = new Prefix("-T");
+	public static final Prefix PREFIX_DESCRIPTION = new Prefix("-d");
+	public static final Prefix PREFIX_DEADLINE = new Prefix("-by");
+	public static final Prefix PREFIX_RECURRENCE = new Prefix("-r");
+	public static final Prefix PREFIX_HOURS = new Prefix("-h");
+	public static final Prefix PREFIX_MINUTES = new Prefix("-m");
+	public static final Prefix PREFIX_TIME_MULTIPLE = new Prefix("-t");
 
 	/* NLP Prefix definitions */
 	public static final Prefix PREFIX_NLP_TIME = new Prefix(",");


### PR DESCRIPTION
Edit command edit INDEX -T will clear all existing tags for a task. prefix for time is changed to -t, prefix for tag is changed to -T.